### PR TITLE
add typescript declarations file

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,74 @@
+type SerializableValue = boolean | number | string | null | SerializableArray | SerializableObject;
+type SerializableArray = Array<SerializableValue>;
+interface SerializableObject {
+    [key: string | number]: SerializableValue;
+}
+
+export interface SingularLinkParams {
+    deeplink: string;
+    passthrough: string;
+    isDeferred: boolean;
+}
+
+export class SingularConfig {
+    constructor(apikey: string, secret: string);
+
+    withSessionTimeoutInSec(sessionTimeout: number): SingularConfig;
+    withCustomUserId(customUserId: number): SingularConfig;
+    withSingularLink(handler: (params: SingularLinkParams) => void): SingularConfig;
+
+    withSkAdNetworkEnabled(enabled: boolean): SingularConfig;
+    withManualSkanConversionManagement(): SingularConfig;
+    withConversionValueUpdatedHandler(handler: (value: number) => void): SingularConfig;
+    withWaitForTrackingAuthorizationWithTimeoutInterval(interval: number): SingularConfig;
+
+    withLimitDataSharing(shouldLimitDataSharing: boolean): SingularConfig;
+}
+
+export class SingularPurchase {
+    constructor(revenue: string, currency: string);
+
+    getPurchaseValues(): SerializableObject;
+}
+
+export class SingularIOSPurchase extends SingularPurchase {
+    constructor(revenue: string, currency: string, productId: string, transactionId: string, receipt: string);
+}
+
+export class SingularAndroidPurchase extends SingularPurchase {
+    constructor(revenue: string, currency: string, receipt: string, signature: string);
+}
+
+export class Singular {
+    static init(config: SingularConfig): void;
+
+    static setCustomUserId(customUserId: string): void;
+    static unsetCustomUserId(): void;
+    static setDeviceCustomUserId(customUserId: string): void;
+
+    static event(eventName: string): void;
+    static eventWithArgs(eventName: string, args: SerializableObject): void;
+
+    static revenue(currency: string, amount: number): void;
+    static revenueWithArgs(currency: string, amount: number, args: SerializableObject): void;
+    static customRevenue(eventName: string, currency: string, amount: number): void;
+    static customRevenueWithArgs(eventName: string, currency: string, amount: number, args: SerializableObject): void;
+
+    static inAppPurchase(eventName: string, purchase: SingularPurchase): void;
+    static inAppPurchaseWithArgs(eventName: string, purchase: SingularPurchase, args: SerializableObject): void;
+
+    static setUninstallToken(token: string): void;
+
+    static trackingOptIn(): void;
+    static trackingUnder13(): void;
+    static stopAllTracking(): void;
+    static resumeAllTracking(): void;
+    static isAllTrackingStopped(): boolean;
+
+    static limitDataSharing(shoudlLimitDataSharing: boolean): void;
+    static getLimitDataSharing(): boolean;
+
+    static skanUpdateConversionValue(conversionValue: number): boolean;
+    static skanGetConversionValue(): number | null;
+    static skanRegisterAppForAdNetworkAttribution(): void;
+}

--- a/package.json
+++ b/package.json
@@ -13,8 +13,10 @@
     "Singular.js",
     "SingularConfig.js",
     "SingularPurchase.js",
-    "index.js"
+    "index.js",
+    "index.d.ts"
   ],
+  "types": "./index.d.ts",
   "devDependencies": {
     "@babel/core": "7.7.4",
     "@babel/runtime": "7.7.4",


### PR DESCRIPTION
We're using the Singular react-native SDK in a react native project with typescript, so for a while we've had our own types declaration file like so:

```ts
declare module 'singular-react-native' {
  export class SingularConfig {
    // etc.
  }
}
```

I've simply copied the type definitions we use internally into this `index.d.ts` file.

Is this something your team would be willing to add to the official package?  I'm guessing other Singular users may benefit from this at some point.