### PR TITLE
Fix iOS auto-linking

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "android/build.gradle",
     "ios/SingularBridge.h",
     "ios/SingularBridge.m",
+    "ios/SingularReactNative.xcodeproj/project.pbxproj",
     "Singular-React-Native.podspec",
     "Singular.js",
     "SingularConfig.js",


### PR DESCRIPTION
Fixes https://github.com/singular-labs/react-native-sdk/issues/8

Just having the xcode project file present in the package within node_modules should be enough to get auto-linking working with iOS.

I tested this by
- manually copying `SingularReactNative.xcodeproj/project.pbxproj` into `node_modules/singular-react-native/ios` in my react native app project 
- removing `pod 'Singular-React-Native', :path => "../node_modules/singular-react-native"` from my app's Podfile
- `rm -rf ios/Pods` in my app
- `pod install`

And I know it works when I see
```
Installing Singular-React-Native (1.1.6)
Installing Singular-SDK (10.3.0)
```
in the output of `pod install`