### PR TITLE
fix wrong type for customUserId to string instead of a number

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -14,7 +14,7 @@ export class SingularConfig {
     constructor(apikey: string, secret: string);
 
     withSessionTimeoutInSec(sessionTimeout: number): SingularConfig;
-    withCustomUserId(customUserId: number): SingularConfig;
+    withCustomUserId(customUserId: string): SingularConfig;
     withSingularLink(handler: (params: SingularLinkParams) => void): SingularConfig;
 
     withSkAdNetworkEnabled(enabled: boolean): SingularConfig;


### PR DESCRIPTION
Fixes:
Terminating app due to uncaught exception 'NSInvalidArgumentException', reason: '-[__NSCFNumber length]: