### PR TITLE
fix NativeEventEmitter warnings

### DIFF
--- a/android/src/main/java/net/singular/react_native/SingularBridgeModule.java
+++ b/android/src/main/java/net/singular/react_native/SingularBridgeModule.java
@@ -262,4 +262,14 @@ public class SingularBridgeModule extends ReactContextBaseJavaModule {
             Singular.init(reactContext, config);
         }
     }
+
+    @ReactMethod
+    public void addListener(String eventName) {
+        // Keep: Required for RN built in Event Emitter Calls.
+    }
+
+    @ReactMethod
+    public void removeListeners(Integer count) {
+        // Keep: Required for RN built in Event Emitter Calls.
+    }
 }


### PR DESCRIPTION
`NativeEventEmitter` requires two methods: `addListener` & `removeListeners`, and  `SingularBridge` class doesn't have these methods

Warnings:
![image](https://user-images.githubusercontent.com/58908279/149599044-1744c568-ae02-4c2b-8730-e3a6cba7b4c5.png)

## Environment: 
react: 17.0.2
react-native: 0.66.2
singular-react-native: ^3.0.0
