### PR TITLE
added config plugin

### DIFF
--- a/app.plugin.js
+++ b/app.plugin.js
@@ -1,0 +1,29 @@
+const { AndroidConfig, withProjectBuildGradle } = require('@expo/config-plugins');
+
+const withSingularPermissions = (config) => {
+  return AndroidConfig.Permissions.withPermissions(config, [
+    'android.permission.INTERNET',
+    'android.permission.ACCESS_NETWORK_STATE',
+    'com.google.android.finsky.permission.BIND_GET_INSTALL_REFERRER_SERVICE',
+    'com.android.vending.CHECK_LICENSE',
+    'com.google.android.gms.permission.AD_ID',
+  ]);
+};
+
+const withSingularProjectBuildGradle = (config) => {
+  return withProjectBuildGradle(config, async (config) => {
+    config.modResults.contents = config.modResults.contents.replace(
+      /allprojects {(?:.|\n)*repositories {/m,
+      str => `${str}\n        maven { url 'https://maven.singular.net/' }`
+    )
+
+    return config;
+  });
+};
+
+module.exports = (config) => {
+  config = withSingularPermissions(config);
+  config = withSingularProjectBuildGradle(config);
+
+  return config;
+};

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "Attributes.js",
     "Events.js",
     "index.js",
+    "app.plugin.js",
     "index.d.ts"
   ],
   "types": "./index.d.ts",


### PR DESCRIPTION
## Title and description

Add a config plugin for expo, to avoid manually modifying manifest file and build.gradle


## Type of change

Check the relevant option:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API changes (requires wrappers implementation)
- [ ] This change requires a documentation update




## Details

In some expo build pipelines (like EAS) there is no chance to modify generated native code (manifest, build.gradle)
A config plugin was added to perform those actions automatically as described here:

https://docs.expo.dev/config-plugins/introduction/





## How Has This Been Tested?

Tested basic functionality with a newly created Expo app with build using EAS for ios and android


## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation - if relevant
- [x] I have added tests that cover new code or fix
- [x] Existing unit tests pass locally with my changes
- [x] Relevant code added to testing app - if relevant
