### PR TITLE
added espDomains to singular config

### DIFF
--- a/SingularConfig.js
+++ b/SingularConfig.js
@@ -21,6 +21,7 @@ export class SingularConfig {
     globalProperties;
     collectOAID
     enableLogging;
+    espDomains;
 
 
     constructor(apikey, secret) {
@@ -111,5 +112,9 @@ export class SingularConfig {
     withLogLevel(level) {
         this.logLevel = level;
         return this;
+    }
+
+    withEspDomains(domains) {
+        this.espDomains = domains;
     }
 }

--- a/android/src/main/java/net/singular/react_native/SingularBridgeModule.java
+++ b/android/src/main/java/net/singular/react_native/SingularBridgeModule.java
@@ -27,6 +27,7 @@ import org.json.JSONObject;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 
@@ -172,6 +173,20 @@ public class SingularBridgeModule extends ReactContextBaseJavaModule {
             String secret = configJson.optString("secret", null);
 
             config = new SingularConfig(apikey, secret);
+
+            JSONArray espDomains = configJson.optJSONArray("espDomains");
+
+            if (espDomains != null && espDomains.length() >0){
+                List<String> domainsList = new LinkedList<>();
+                for (int i = 0 ; i < espDomains.length() ; i++){
+                    String domain = espDomains.getString(i);
+                    if (domain != null && domain.length() >0){
+                        domainsList.add(domain);
+                    }
+                }
+                config.withESPDomains(domainsList);
+
+            }
 
             long ddlTimeoutSec = configJson.optLong("ddlTimeoutSec", 0);
 

--- a/ios/SingularBridge.m
+++ b/ios/SingularBridge.m
@@ -61,6 +61,7 @@ RCT_EXPORT_METHOD(init:(NSString*) jsonSingularConfig){
     // Singular Links fields
     singularConfig.launchOptions = launchOptions;
     singularConfig.supportedDomains = [singularConfigDict objectForKey:@"supportedDomains"];
+    singularConfig.espDomains = [singularConfigDict objectForKey:@"espDomains"];
     singularConfig.shortLinkResolveTimeOut = [[singularConfigDict objectForKey:@"shortLinkResolveTimeout"] longValue];
     singularConfig.singularLinksHandler = ^(SingularLinkParams * params){
         [SingularBridge handleSingularLink:params];


### PR DESCRIPTION
## Title and description

added an option to pass ESP domains to the native SDK for both android and iOS


## Type of change

Check the relevant option:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API changes (requires wrappers implementation)
- [ ] This change requires a documentation update

## How Has This Been Tested?

tested with debugger on native SDK layers

